### PR TITLE
Remove unused JPA exception import

### DIFF
--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/usecase/ReprocessFailedAlertUseCase.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/usecase/ReprocessFailedAlertUseCase.java
@@ -8,7 +8,6 @@ import br.dev.rodrigopinheiro.alertacomunidade.domain.model.FailedAlertNotificat
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.input.ReprocessFailedAlertUseCasePort;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.AlertPublisherPort;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.FailedAlertRepositoryPort;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;


### PR DESCRIPTION
## Summary
- clean up `ReprocessFailedAlertUseCase` by removing an unused `EntityNotFoundException` import

## Testing
- `mvn test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c7d6058832aa6306535a57fd4c9