### PR TITLE
Implement subscriber notifications

### DIFF
--- a/AlertaComunidade/pom.xml
+++ b/AlertaComunidade/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -42,14 +42,23 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.amqp</groupId>
-			<artifactId>spring-rabbit-stream</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-mail</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.twilio.sdk</groupId>
+                        <artifactId>twilio</artifactId>
+                        <version>8.24.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.amqp</groupId>
+                        <artifactId>spring-rabbit-stream</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.retry</groupId>

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/mapper/SubscriberMapper.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/mapper/SubscriberMapper.java
@@ -1,0 +1,18 @@
+package br.dev.rodrigopinheiro.alertacomunidade.application.mapper;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+import br.dev.rodrigopinheiro.alertacomunidade.dto.SubscriberRequestDTO;
+import br.dev.rodrigopinheiro.alertacomunidade.dto.SubscriberResponseDTO;
+
+public class SubscriberMapper {
+    public static Subscriber toEntity(SubscriberRequestDTO dto) {
+        Subscriber s = new Subscriber();
+        s.setEmail(dto.getEmail());
+        s.setPhoneNumber(dto.getPhoneNumber());
+        return s;
+    }
+
+    public static SubscriberResponseDTO toResponse(Subscriber entity) {
+        return new SubscriberResponseDTO(entity.getId(), entity.getEmail(), entity.getPhoneNumber());
+    }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/usecase/RegisterSubscriberUseCase.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/application/usecase/RegisterSubscriberUseCase.java
@@ -1,0 +1,20 @@
+package br.dev.rodrigopinheiro.alertacomunidade.application.usecase;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.input.RegisterSubscriberInputPort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.SubscriberRepositoryPort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RegisterSubscriberUseCase implements RegisterSubscriberInputPort {
+    private final SubscriberRepositoryPort repository;
+
+    public RegisterSubscriberUseCase(SubscriberRepositoryPort repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Subscriber register(Subscriber subscriber) {
+        return repository.save(subscriber);
+    }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/model/Subscriber.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/model/Subscriber.java
@@ -1,0 +1,30 @@
+package br.dev.rodrigopinheiro.alertacomunidade.domain.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+
+@Entity
+@Table(name = "subscribers")
+public class Subscriber {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Email
+    @Column(name = "email")
+    private String email;
+
+    @Pattern(regexp = "^\+?\d{10,15}$")
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/input/RegisterSubscriberInputPort.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/input/RegisterSubscriberInputPort.java
@@ -1,0 +1,7 @@
+package br.dev.rodrigopinheiro.alertacomunidade.domain.port.input;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+
+public interface RegisterSubscriberInputPort {
+    Subscriber register(Subscriber subscriber);
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/output/NotificationServicePort.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/output/NotificationServicePort.java
@@ -1,0 +1,6 @@
+package br.dev.rodrigopinheiro.alertacomunidade.domain.port.output;
+
+public interface NotificationServicePort {
+    void sendEmail(String to, String subject, String body);
+    void sendSms(String to, String message);
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/output/SubscriberRepositoryPort.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/domain/port/output/SubscriberRepositoryPort.java
@@ -1,0 +1,9 @@
+package br.dev.rodrigopinheiro.alertacomunidade.domain.port.output;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+import java.util.List;
+
+public interface SubscriberRepositoryPort {
+    Subscriber save(Subscriber subscriber);
+    List<Subscriber> findAll();
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/dto/SubscriberRequestDTO.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/dto/SubscriberRequestDTO.java
@@ -1,0 +1,18 @@
+package br.dev.rodrigopinheiro.alertacomunidade.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+
+public class SubscriberRequestDTO {
+    @Email(message = "Email inválido")
+    private String email;
+
+    @Pattern(regexp = "^\+?\d{10,15}$", message = "Telefone inválido")
+    private String phoneNumber;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/dto/SubscriberResponseDTO.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/dto/SubscriberResponseDTO.java
@@ -1,0 +1,23 @@
+package br.dev.rodrigopinheiro.alertacomunidade.dto;
+
+public class SubscriberResponseDTO {
+    private Long id;
+    private String email;
+    private String phoneNumber;
+
+    public SubscriberResponseDTO() {}
+    public SubscriberResponseDTO(Long id, String email, String phoneNumber) {
+        this.id = id;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/messaging/RabbitAlertListener.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/messaging/RabbitAlertListener.java
@@ -7,6 +7,9 @@ import br.dev.rodrigopinheiro.alertacomunidade.domain.model.AlertNotification;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.model.FailedAlertNotification;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.AlertRepositoryPort;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.FailedAlertRepositoryPort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.NotificationServicePort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.SubscriberRepositoryPort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -26,10 +29,17 @@ public class RabbitAlertListener {
     private static final Logger logger = LoggerFactory.getLogger(RabbitAlertListener.class);
     private final AlertRepositoryPort alertRepository;
     private final FailedAlertRepositoryPort failedRepository;
+    private final SubscriberRepositoryPort subscriberRepository;
+    private final NotificationServicePort notificationService;
 
-    public RabbitAlertListener(AlertRepositoryPort repository, FailedAlertRepositoryPort failedRepository) {
+    public RabbitAlertListener(AlertRepositoryPort repository,
+                              FailedAlertRepositoryPort failedRepository,
+                              SubscriberRepositoryPort subscriberRepository,
+                              NotificationServicePort notificationService) {
         this.alertRepository = repository;
         this.failedRepository = failedRepository;
+        this.subscriberRepository = subscriberRepository;
+        this.notificationService = notificationService;
     }
 
     @Retryable(
@@ -43,6 +53,7 @@ public class RabbitAlertListener {
         try {
             alert.setStatus(AlertStatus.DELIVERED);
             alertRepository.save(alert);
+            notifySubscribers(alert);
         } catch (AlertProcessingException e) {
             logger.error("Falha ao processar alerta: ID={} - Motivo: {}", alert.getId(), e.getMessage(), e);
             throw new AlertProcessingException("Erro ao processar alerta", e);
@@ -60,6 +71,7 @@ public class RabbitAlertListener {
         try {
             alert.setStatus(AlertStatus.DELIVERED);
             alertRepository.save(alert);
+            notifySubscribers(alert);
         } catch (AlertProcessingException e) {
             logger.error("Falha ao processar alerta: ID={} - Motivo: {}", alert.getId(), e.getMessage(), e);
             throw new AlertProcessingException("Erro ao processar alerta", e);
@@ -76,6 +88,7 @@ public class RabbitAlertListener {
         try {
             alert.setStatus(AlertStatus.DELIVERED);
             alertRepository.save(alert);
+            notifySubscribers(alert);
         } catch (AlertProcessingException e) {
             logger.error("Falha ao processar alerta: ID={} - Motivo: {}", alert.getId(), e.getMessage(), e);
             throw new AlertProcessingException("Erro ao processar alerta", e);
@@ -90,5 +103,18 @@ public class RabbitAlertListener {
         failedRepository.save(failed);
 
         logger.info("Alerta ID={} persistido com status de falha em 'failed_alert_notifications'", alert.getId());
+    }
+
+    private void notifySubscribers(AlertNotification alert) {
+        String subject = "Alerta: " + alert.getAlertType();
+        String msg = alert.getMessage();
+        for (Subscriber s : subscriberRepository.findAll()) {
+            if (s.getEmail() != null) {
+                notificationService.sendEmail(s.getEmail(), subject, msg);
+            }
+            if (s.getPhoneNumber() != null) {
+                notificationService.sendSms(s.getPhoneNumber(), msg);
+            }
+        }
     }
 }

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/notification/NotificationServiceImpl.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/notification/NotificationServiceImpl.java
@@ -1,0 +1,39 @@
+package br.dev.rodrigopinheiro.alertacomunidade.infrastructure.notification;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.NotificationServicePort;
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationServiceImpl implements NotificationServicePort {
+    private final JavaMailSender mailSender;
+    private final String fromNumber;
+
+    public NotificationServiceImpl(JavaMailSender mailSender,
+                                   @Value("${twilio.account-sid}") String sid,
+                                   @Value("${twilio.auth-token}") String token,
+                                   @Value("${twilio.from-number}") String fromNumber) {
+        this.mailSender = mailSender;
+        this.fromNumber = fromNumber;
+        Twilio.init(sid, token);
+    }
+
+    @Override
+    public void sendEmail(String to, String subject, String body) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(to);
+        msg.setSubject(subject);
+        msg.setText(body);
+        mailSender.send(msg);
+    }
+
+    @Override
+    public void sendSms(String to, String message) {
+        Message.creator(new PhoneNumber(to), new PhoneNumber(fromNumber), message).create();
+    }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/persistence/adapter/JpaSubscriberRepository.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/persistence/adapter/JpaSubscriberRepository.java
@@ -1,0 +1,27 @@
+package br.dev.rodrigopinheiro.alertacomunidade.infrastructure.persistence.adapter;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.SubscriberRepositoryPort;
+import br.dev.rodrigopinheiro.alertacomunidade.infrastructure.persistence.jpa.SpringDataSubscriberRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class JpaSubscriberRepository implements SubscriberRepositoryPort {
+    private final SpringDataSubscriberRepository delegate;
+
+    public JpaSubscriberRepository(SpringDataSubscriberRepository delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Subscriber save(Subscriber subscriber) {
+        return delegate.save(subscriber);
+    }
+
+    @Override
+    public List<Subscriber> findAll() {
+        return delegate.findAll();
+    }
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/persistence/jpa/SpringDataSubscriberRepository.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/persistence/jpa/SpringDataSubscriberRepository.java
@@ -1,0 +1,9 @@
+package br.dev.rodrigopinheiro.alertacomunidade.infrastructure.persistence.jpa;
+
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SpringDataSubscriberRepository extends JpaRepository<Subscriber, Long> {
+}

--- a/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/rest/SubscriberController.java
+++ b/AlertaComunidade/src/main/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/rest/SubscriberController.java
@@ -1,0 +1,26 @@
+package br.dev.rodrigopinheiro.alertacomunidade.infrastructure.rest;
+
+import br.dev.rodrigopinheiro.alertacomunidade.application.mapper.SubscriberMapper;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.input.RegisterSubscriberInputPort;
+import br.dev.rodrigopinheiro.alertacomunidade.dto.SubscriberRequestDTO;
+import br.dev.rodrigopinheiro.alertacomunidade.dto.SubscriberResponseDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/subscribers")
+public class SubscriberController {
+    private final RegisterSubscriberInputPort registerUseCase;
+
+    public SubscriberController(RegisterSubscriberInputPort registerUseCase) {
+        this.registerUseCase = registerUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<SubscriberResponseDTO> register(@Valid @RequestBody SubscriberRequestDTO dto){
+        var entity = registerUseCase.register(SubscriberMapper.toEntity(dto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(SubscriberMapper.toResponse(entity));
+    }
+}

--- a/AlertaComunidade/src/main/resources/application.yml
+++ b/AlertaComunidade/src/main/resources/application.yml
@@ -34,9 +34,26 @@ spring:
     username: guest
     password: guest
 
+  mail:
+    host: smtp
+    port: 1025
+    username: user
+    password: pass
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false
+
   jackson:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false
+
+twilio:
+  account-sid: ${TWILIO_ACCOUNT_SID:ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}
+  auth-token: ${TWILIO_AUTH_TOKEN:token}
+  from-number: ${TWILIO_FROM_NUMBER:+1234567890}
 
 
 # Converte camelCase -> snake_case no banco de dados (opcional)

--- a/AlertaComunidade/src/main/resources/db/migration/V4__create_subscribers.sql
+++ b/AlertaComunidade/src/main/resources/db/migration/V4__create_subscribers.sql
@@ -1,0 +1,5 @@
+CREATE TABLE subscribers (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255),
+    phone_number VARCHAR(20)
+);

--- a/AlertaComunidade/src/test/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/messaging/RabbitAlertListenerTest.java
+++ b/AlertaComunidade/src/test/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/messaging/RabbitAlertListenerTest.java
@@ -7,6 +7,9 @@ import br.dev.rodrigopinheiro.alertacomunidade.domain.model.AlertNotification;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.model.FailedAlertNotification;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.AlertRepositoryPort;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.FailedAlertRepositoryPort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.SubscriberRepositoryPort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.port.output.NotificationServicePort;
+import br.dev.rodrigopinheiro.alertacomunidade.domain.model.Subscriber;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -29,6 +32,12 @@ public class RabbitAlertListenerTest {
     @Mock
     private FailedAlertRepositoryPort failedARepository;
 
+    @Mock
+    private SubscriberRepositoryPort subscriberRepository;
+
+    @Mock
+    private NotificationServicePort notificationService;
+
     @InjectMocks
     private RabbitAlertListener listener;
 
@@ -48,12 +57,18 @@ public class RabbitAlertListenerTest {
                 AlertType.FIRE,
                 AlertStatus.RECEIVED
         );
+        Subscriber s = new Subscriber();
+        s.setEmail("a@a.com");
+        s.setPhoneNumber("+11111111111");
+        when(subscriberRepository.findAll()).thenReturn(java.util.List.of(s));
 
         //when
         listener.receiveCritical(alert);
 
         //then
         verify(alertRepository).save(alertCaptor.capture());
+        verify(notificationService).sendEmail("a@a.com", "Alerta: " + alert.getAlertType(), alert.getMessage());
+        verify(notificationService).sendSms("+11111111111", alert.getMessage());
 
         AlertNotification saved = alertCaptor.getValue();
         verifyListener(saved, alert);
@@ -70,12 +85,18 @@ public class RabbitAlertListenerTest {
                 AlertType.MEDICAL,
                 AlertStatus.RECEIVED
         );
+        Subscriber s = new Subscriber();
+        s.setEmail("b@b.com");
+        s.setPhoneNumber("+22222222222");
+        when(subscriberRepository.findAll()).thenReturn(java.util.List.of(s));
 
         //when
         listener.receiveNormal(alert);
 
         //then
         verify(alertRepository).save(alertCaptor.capture());
+        verify(notificationService).sendEmail("b@b.com", "Alerta: " + alert.getAlertType(), alert.getMessage());
+        verify(notificationService).sendSms("+22222222222", alert.getMessage());
 
         AlertNotification saved = alertCaptor.getValue();
         verifyListener(saved, alert);
@@ -92,12 +113,18 @@ public class RabbitAlertListenerTest {
                 AlertType.OTHER,
                 AlertStatus.RECEIVED
         );
+        Subscriber s = new Subscriber();
+        s.setEmail("c@c.com");
+        s.setPhoneNumber("+33333333333");
+        when(subscriberRepository.findAll()).thenReturn(java.util.List.of(s));
 
         //when
         listener.receiveLog(alert);
 
         //then
         verify(alertRepository).save(alertCaptor.capture());
+        verify(notificationService).sendEmail("c@c.com", "Alerta: " + alert.getAlertType(), alert.getMessage());
+        verify(notificationService).sendSms("+33333333333", alert.getMessage());
 
         AlertNotification saved = alertCaptor.getValue();
         verifyListener(saved, alert);


### PR DESCRIPTION
## Summary
- support email and SMS alerts with Twilio and Spring Boot Mail
- add subscriber entity and registration endpoint
- notify all registered subscribers when consuming alerts from the queue
- create table migration for subscribers

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684b66bf4d30832aaafdb42224283c4e