### PR TITLE
Fix GlobalExceptionHandlerTest for new ApiErrorResponse record

### DIFF
--- a/AlertaComunidade/src/test/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/rest/GlobalExceptionHandlerTest.java
+++ b/AlertaComunidade/src/test/java/br/dev/rodrigopinheiro/alertacomunidade/infrastructure/rest/GlobalExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package br.dev.rodrigopinheiro.alertacomunidade.infrastructure.rest;
 
 import br.dev.rodrigopinheiro.alertacomunidade.domain.exception.FailedAlertNotFoundException;
 import br.dev.rodrigopinheiro.alertacomunidade.domain.exception.ResourceNotFoundException;
+import br.dev.rodrigopinheiro.alertacomunidade.dto.ApiErrorResponse;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -31,14 +31,14 @@ public class GlobalExceptionHandlerTest {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getRequestURI()).thenReturn("/teste");
         // when
-        ResponseEntity<Object> response = handler.resourceNotFound(ex);
-        Map<String, Object> body = castBody(response);
+        ResponseEntity<ApiErrorResponse> response = handler.resourceNotFound(ex, request);
+        ApiErrorResponse body = castBody(response);
 
 
         // then
-        assertThat(body.get("status")).isEqualTo(404);
-        assertThat(body.get("error")).isEqualTo("Not Found");
-        assertThat(body.get("message")).isEqualTo("Recurso não encontrado");
+        assertThat(body.status()).isEqualTo(404);
+        assertThat(body.error()).isEqualTo("Not Found");
+        assertThat(body.message()).isEqualTo("Recurso não encontrado");
     }
 
     @Test
@@ -46,32 +46,36 @@ public class GlobalExceptionHandlerTest {
         // given
         long id = 41L;
         FailedAlertNotFoundException ex = new FailedAlertNotFoundException(id);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/alerts");
 
         // when
-        ResponseEntity<Object> response = handler.failedAlertNotFound(ex);
-        Map<String, Object> body = castBody(response);
+        ResponseEntity<ApiErrorResponse> response = handler.failedAlertNotFound(ex, request);
+        ApiErrorResponse body = castBody(response);
 
         // then
-        assertThat(body.get("status")).isEqualTo(404);
-        assertThat(body.get("error")).isEqualTo("Alerta com falha não encontrado");
-        assertThat(body.get("message")).isEqualTo("Alerta com falha ID " + id + " não encontrado");
+        assertThat(body.status()).isEqualTo(404);
+        assertThat(body.error()).isEqualTo("Alerta com falha não encontrado");
+        assertThat(body.message()).isEqualTo("Alerta com falha ID " + id + " não encontrado");
     }
 
     @Test
     void shouldHandleUnrecognizedPropertyException() {
         //given
         UnrecognizedPropertyException ex = new UnrecognizedPropertyException(null, "Mensagem", null, String.class, "campoInvalido", null);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/alerts");
 
         //when
-        ResponseEntity<Object> response = handler.unrecognizedProperty(ex);
-        Map<String, Object> body = castBody(response);
+        ResponseEntity<ApiErrorResponse> response = handler.unrecognizedProperty(ex, request);
+        ApiErrorResponse body = castBody(response);
 
         //then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(body.get("status")).isEqualTo(400);
-        assertThat(body.get("error")).isEqualTo("Campo inválido no JSON");
-        assertThat(body.get("message")).isEqualTo("Campo não reconhecido: campoInvalido");
-        assertThat(body.get("path")).isEqualTo("/alerts");
+        assertThat(body.status()).isEqualTo(400);
+        assertThat(body.error()).isEqualTo("Campo inválido no JSON");
+        assertThat(body.message()).isEqualTo("Campo não reconhecido: campoInvalido");
+        assertThat(body.path()).isEqualTo("/alerts");
     }
 
     @Test
@@ -89,58 +93,60 @@ public class GlobalExceptionHandlerTest {
         // when
         when(ex.getBindingResult()).thenReturn(bindingResult);
         when(ex.getMessage()).thenReturn("Erro de validação");
-        ResponseEntity<Object> response = handler.methodArgumentNotValid(ex);
-        when(ex.getBindingResult()).thenReturn(bindingResult);
-        when(ex.getMessage()).thenReturn("Erro de validação");
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/alerts");
+        ResponseEntity<ApiErrorResponse> response = handler.methodArgumentNotValid(ex, request);
 
 
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        Map<String, Object> body = castBody(response);
-        assertThat(body.get("status")).isEqualTo(400);
-        assertThat(body.get("error")).isEqualTo("Bad Request");
-        assertThat(body.get("message")).isEqualTo("Erro de validação nos campos enviados.");
-        Map<String, String> fields = (Map<String, String>) body.get("fields");
-        assertThat(fields.get("origin")).isEqualTo("Origem é obrigatória");
+        ApiErrorResponse body = castBody(response);
+        assertThat(body.status()).isEqualTo(400);
+        assertThat(body.error()).isEqualTo("Bad Request");
+        assertThat(body.message()).isEqualTo("Erro de validação nos campos enviados.");
+        assertThat(body.fields().get("origin")).isEqualTo("Origem é obrigatória");
 
     }
     @Test
     void shouldHandleIllegalArgumentException() {
         //given
         IllegalArgumentException ex = new IllegalArgumentException("Argumento inválido");
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/alerts");
 
         //when
-        ResponseEntity<Object> response = handler.handleIllegalArgument(ex);
-        Map<String, Object> body = castBody(response);
+        ResponseEntity<ApiErrorResponse> response = handler.handleIllegalArgument(ex, request);
+        ApiErrorResponse body = castBody(response);
 
         //then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(body.get("status")).isEqualTo(400);
-        assertThat(body.get("error")).isEqualTo("Bad Request");
-        assertThat(body.get("message")).isEqualTo("Argumento inválido");
+        assertThat(body.status()).isEqualTo(400);
+        assertThat(body.error()).isEqualTo("Bad Request");
+        assertThat(body.message()).isEqualTo("Argumento inválido");
     }
 
     @Test
     void shouldHandleRuntimeException() {
         //given
         RuntimeException ex = new RuntimeException("Erro interno inesperado");
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getRequestURI()).thenReturn("/alerts");
 
         //when
-        ResponseEntity<Object> response = handler.handleRuntimeException(ex);
-        Map<String, Object> body = castBody(response);
+        ResponseEntity<ApiErrorResponse> response = handler.handleGenericException(ex, request);
+        ApiErrorResponse body = castBody(response);
 
         //then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(body.get("status")).isEqualTo(500);
-        assertThat(body.get("error")).isEqualTo("Internal Server Error");
-        assertThat(body.get("message")).isEqualTo("Erro interno ao processar a requisição.");
+        assertThat(body.status()).isEqualTo(500);
+        assertThat(body.error()).isEqualTo("Internal Server Error");
+        assertThat(body.message()).isEqualTo("Erro interno ao processar a requisição.");
     }
 
     // helper para cast seguro
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> castBody(ResponseEntity<Object> response) {
-        assertThat(response.getBody()).isInstanceOf(Map.class);
-        return (Map<String, Object>) response.getBody();
+    private ApiErrorResponse castBody(ResponseEntity<ApiErrorResponse> response) {
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody();
     }
 }


### PR DESCRIPTION
## Summary
- update `GlobalExceptionHandlerTest` to use `ApiErrorResponse` record
- provide `HttpServletRequest` mocks for each handler call

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684f25189244832aa192ff11111d4850