### PR TITLE
Add SMTP auth and STARTTLS env vars

### DIFF
--- a/.env
+++ b/.env
@@ -20,6 +20,8 @@ MAIL_HOST=smtp
 MAIL_PORT=1025
 MAIL_USERNAME=user
 MAIL_PASSWORD=pass
+MAIL_SMTP_AUTH=false
+MAIL_SMTP_STARTTLS_ENABLE=false
 
 # Twilio configuration
 TWILIO_ACCOUNT_SID=your_account_sid

--- a/AlertaComunidade/src/main/resources/application.yml
+++ b/AlertaComunidade/src/main/resources/application.yml
@@ -42,9 +42,9 @@ spring:
     properties:
       mail:
         smtp:
-          auth: false
+          auth: ${MAIL_SMTP_AUTH:false}
           starttls:
-            enable: false
+            enable: ${MAIL_SMTP_STARTTLS_ENABLE:false}
   jackson:
     serialization:
       WRITE_DATES_AS_TIMESTAMPS: false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Central de notificações para emergências comunitárias construída em Spring 
    A aplicação ficará disponível em `http://localhost:8080`.
    O RabbitMQ pode ser acessado em `http://localhost:15672` (usuário/senha padrão: guest/guest).
    Ajustes de configuração podem ser realizados no arquivo `.env`.
+   Para servidores SMTP que exigem autenticação e STARTTLS (ex.: Gmail na porta 587),
+   defina `MAIL_SMTP_AUTH=true` e `MAIL_SMTP_STARTTLS_ENABLE=true`.
 
 ## Arquitetura e boas práticas
 


### PR DESCRIPTION
## Summary
- expose `MAIL_SMTP_AUTH` and `MAIL_SMTP_STARTTLS_ENABLE`
- wire spring mail config to use new variables
- document Gmail requirements in README

## Testing
- `./mvnw test -q` *(fails: failed to fetch maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685470d0729c832a887adae2402cc7ff